### PR TITLE
Firebase Auth UI - no https prefix for auth domain

### DIFF
--- a/src/firemore/config.cljs
+++ b/src/firemore/config.cljs
@@ -44,9 +44,9 @@
 
 (def FIREBASE_DATABASE_URL (https FIREBASE_PROJECT_ID ".firebaseio.com"))
 
-(def FIREBASE_STORAGE_BUCKET (https FIREBASE_PROJECT_ID ".appspot.com"))
+(def FIREBASE_STORAGE_BUCKET (str FIREBASE_PROJECT_ID ".appspot.com"))
 
-(def FIREBASE_AUTH_DOMAIN (https FIREBASE_PROJECT_ID ".firebaseapp.com"))
+(def FIREBASE_AUTH_DOMAIN (str FIREBASE_PROJECT_ID ".firebaseapp.com"))
 
 ;; Constants
 


### PR DESCRIPTION
This plays well with Firebase Auth UI which expects the Auth Domain to be just a domain, without protocol.